### PR TITLE
Fix report generation typo

### DIFF
--- a/apps/reporting/utils/charts/polar.py
+++ b/apps/reporting/utils/charts/polar.py
@@ -65,7 +65,7 @@ def radar_factory(num_vars, frame='circle'):
             half = (len(texts) - 1) // 2
             for t in texts[1:half]:
                 t.set_horizontalalignment('left')
-            for t in texts[-half + 1:]:
+            for t in texts[half + 1:]:
                 t.set_horizontalalignment('right')
 
         def _gen_axes_patch(self):
@@ -109,7 +109,7 @@ class VulnCategoryPolarChart:
         amount = []
         for cat in categories:
             counter = Vulnerability.objects.filter(
-                project=project, template__categories__name=cat.name).count()
+                project=project, template__category__name=cat.name).count()
             if counter and len(labels) <= 10:
                 labels.append(cat.display_name)
                 amount.append(counter)
@@ -126,7 +126,7 @@ class VulnCategoryPolarChart:
         ax.plot(theta, amount)
         ax.fill(theta, amount, "b", alpha=0.25)
         ax.set_varlabels(labels)
-        ax.tick_params(axis='both', which='major', pad=10)
+        ax.tick_params(axis='both', which='major')
 
         ax.set_theta_direction(-1)
         ax.set_yticklabels([])

--- a/resources/report_templates/default/sections/technical_details.html
+++ b/resources/report_templates/default/sections/technical_details.html
@@ -60,7 +60,7 @@
                 </tr>
                 <tr>
                     <th>Category</th>
-                    <td>{{ vulnerability.template.categories.all.0 }}</td>
+                    <td>{{ vulnerability.template.category }}</td>
                 </tr>
                 {% if vulnerability.cve_id %}
                 <tr>

--- a/resources/report_templates/default/sections/vulnerability_overview.html
+++ b/resources/report_templates/default/sections/vulnerability_overview.html
@@ -69,7 +69,7 @@
         <p>
             In the case of clear deflections, consideration should be given to appropriate countermeasures in these areas.
         </p>
-        <img src="{{ CATEGORY_POLAR_CHART }}" alt="category-chart" style="width: 8cm; max-width: 8cm; height:8cm; margin-left:auto;margin-right:auto; display:block">
+        <img src="{{ CATEGORY_POLAR_CHART }}" alt="category-chart" style="width: 10cm; max-width: 15cm; height:7cm; margin-left:auto;margin-right:auto; display:block">
 
     </section>
 


### PR DESCRIPTION
The report generation task still used *categories* after migrating to *category* foreignkey relationship.